### PR TITLE
feat: Implement multi-repository contributor tracking and categorization

### DIFF
--- a/app/api/github/contributors/route.ts
+++ b/app/api/github/contributors/route.ts
@@ -1,14 +1,19 @@
 /**
  * GitHub Contributors API Route
- * Fetches contributor data from GitHub repository
+ * Fetches contributor data from both repositories (bot and website)
  * Author: nayandas69
- * Repository: https://github.com/nayandas69/discord-role-guardian
+ * Repositories:
+ * - Bot: https://github.com/nayandas69/discord-role-guardian
+ * - Website: https://github.com/nayandas69/drgw
  */
 
 import { NextResponse } from "next/server"
 
-const GITHUB_REPO = "nayandas69/discord-role-guardian"
-const GITHUB_API = `https://api.github.com/repos/${GITHUB_REPO}/contributors`
+const BOT_REPO = "nayandas69/discord-role-guardian"
+const WEBSITE_REPO = "nayandas69/drgw"
+
+const BOT_GITHUB_API = `https://api.github.com/repos/${BOT_REPO}/contributors`
+const WEBSITE_GITHUB_API = `https://api.github.com/repos/${WEBSITE_REPO}/contributors`
 
 export async function GET() {
     try {
@@ -21,19 +26,77 @@ export async function GET() {
             headers["Authorization"] = `token ${process.env.GITHUB_TOKEN}`
         }
 
-        const response = await fetch(GITHUB_API, {
-            headers,
-            next: { revalidate: 3600 }, // Cache for 1 hour
-        })
+        const [botResponse, websiteResponse] = await Promise.all([
+            fetch(BOT_GITHUB_API, {
+                headers,
+                next: { revalidate: 3600 }, // Cache for 1 hour
+            }),
+            fetch(WEBSITE_GITHUB_API, {
+                headers,
+                next: { revalidate: 3600 }, // Cache for 1 hour
+            }),
+        ])
 
-        if (!response.ok) {
-            throw new Error(`GitHub API responded with status: ${response.status}`)
+        if (!botResponse.ok) {
+            throw new Error(`GitHub API responded with status for bot repo: ${botResponse.status}`)
         }
 
-        const contributors = await response.json()
+        if (!websiteResponse.ok) {
+            throw new Error(`GitHub API responded with status for website repo: ${websiteResponse.status}`)
+        }
+
+        const botContributors = await botResponse.json()
+        const websiteContributors = await websiteResponse.json()
+
+        const contributorMap = new Map<
+            string,
+            {
+                login: string
+                contributions: {
+                    bot: number
+                    website: number
+                }
+                avatar_url: string
+                html_url: string
+                type: string
+            }
+        >()
+
+        // Add bot contributors to the map
+        for (const contributor of botContributors) {
+            contributorMap.set(contributor.login, {
+                login: contributor.login,
+                contributions: {
+                    bot: contributor.contributions,
+                    website: 0,
+                },
+                avatar_url: contributor.avatar_url,
+                html_url: contributor.html_url,
+                type: contributor.type,
+            })
+        }
+
+        // Add website contributors to the map (merge if already exists)
+        for (const contributor of websiteContributors) {
+            if (contributorMap.has(contributor.login)) {
+                const existing = contributorMap.get(contributor.login)!
+                existing.contributions.website = contributor.contributions
+            } else {
+                contributorMap.set(contributor.login, {
+                    login: contributor.login,
+                    contributions: {
+                        bot: 0,
+                        website: contributor.contributions,
+                    },
+                    avatar_url: contributor.avatar_url,
+                    html_url: contributor.html_url,
+                    type: contributor.type,
+                })
+            }
+        }
 
         const detailedContributors = await Promise.all(
-            contributors.map(async (contributor: any) => {
+            Array.from(contributorMap.values()).map(async (contributor) => {
                 try {
                     // Fetch user details to get the display name
                     const userResponse = await fetch(`https://api.github.com/users/${contributor.login}`, {
@@ -43,14 +106,38 @@ export async function GET() {
 
                     if (userResponse.ok) {
                         const userData = await userResponse.json()
+
+                        let contributorType = ""
+                        if (contributor.login.toLowerCase() !== "nayandas69") {
+                            if (contributor.contributions.bot > 0 && contributor.contributions.website > 0) {
+                                contributorType = "Bot and Website Contributor"
+                            } else if (contributor.contributions.bot > 0) {
+                                contributorType = "Bot Contributor"
+                            } else if (contributor.contributions.website > 0) {
+                                contributorType = "Website Contributor"
+                            }
+                        }
+
+                        let description = ""
+                        if (contributor.login.toLowerCase() === "nayandas69") {
+                            description =
+                                "Creator and lead developer of Discord Role Guardian. Passionate about open-source and building tools for the Discord community."
+                        } else {
+                            description = userData.bio || "Open source contributor helping improve the project"
+                        }
+
                         return {
                             login: contributor.login,
-                            name: userData.name || contributor.login, // Use display name if available, fallback to username
+                            name: userData.name || contributor.login,
                             avatar: contributor.avatar_url,
-                            contributions: contributor.contributions,
+                            contributions: contributor.contributions.bot + contributor.contributions.website,
+                            botContributions: contributor.contributions.bot,
+                            websiteContributions: contributor.contributions.website,
+                            contributorType,
                             profile: contributor.html_url,
                             type: contributor.type,
                             bio: userData.bio || null,
+                            description,
                         }
                     }
                 } catch (error) {
@@ -58,14 +145,37 @@ export async function GET() {
                 }
 
                 // Fallback if user details fetch fails
+                let contributorType = ""
+                if (contributor.login.toLowerCase() !== "nayandas69") {
+                    if (contributor.contributions.bot > 0 && contributor.contributions.website > 0) {
+                        contributorType = "Bot and Website Contributor"
+                    } else if (contributor.contributions.bot > 0) {
+                        contributorType = "Bot Contributor"
+                    } else if (contributor.contributions.website > 0) {
+                        contributorType = "Website Contributor"
+                    }
+                }
+
+                let description = ""
+                if (contributor.login.toLowerCase() === "nayandas69") {
+                    description =
+                        "Creator and lead developer of Discord Role Guardian. Passionate about open-source and building tools for the Discord community."
+                } else {
+                    description = "Open source contributor helping improve the project"
+                }
+
                 return {
                     login: contributor.login,
                     name: contributor.login,
                     avatar: contributor.avatar_url,
-                    contributions: contributor.contributions,
+                    contributions: contributor.contributions.bot + contributor.contributions.website,
+                    botContributions: contributor.contributions.bot,
+                    websiteContributions: contributor.contributions.website,
+                    contributorType,
                     profile: contributor.html_url,
                     type: contributor.type,
                     bio: null,
+                    description,
                 }
             }),
         )

--- a/app/contributors/page.tsx
+++ b/app/contributors/page.tsx
@@ -1,9 +1,11 @@
 /**
  * Contributors Page
  * Showcase community members and contributors
- * Highlights developers, supporters, and open-source contributors
+ * Highlights developers, supporters, and open-source contributors from both bot and website repos
  * Author: nayandas69
- * Repository: https://github.com/nayandas69/discord-role-guardian
+ * Repositories:
+ * - Bot: https://github.com/nayandas69/discord-role-guardian
+ * - Website: https://github.com/nayandas69/drgw
  */
 
 "use client"
@@ -30,8 +32,12 @@ interface Contributor {
     role: ContributorRole
     avatar: string
     contributions: number
+    botContributions: number
+    websiteContributions: number
+    contributorType: string
     githubUrl: string
     bio: string
+    description: string // Added description field
 }
 
 /**
@@ -51,12 +57,16 @@ interface ContributionType {
  */
 interface GitHubContributor {
     login: string
-    name: string // Added name field for display name
+    name: string
     avatar: string
     contributions: number
+    botContributions: number
+    websiteContributions: number
+    contributorType: string
     profile: string
     type: string
     bio: string | null
+    description: string // Added description field
 }
 
 /**
@@ -134,19 +144,36 @@ export default function ContributorsPage() {
                         role = "maintainer"
                     }
 
-                    const bio =
-                        contributor.login.toLowerCase() === REPO_OWNER.toLowerCase()
-                            ? CREATOR_BIO
-                            : `${contributor.contributions} contributions to Discord Role Guardian`
+                    let bio = ""
+                    if (contributor.login.toLowerCase() === REPO_OWNER.toLowerCase()) {
+                        bio = ""
+                    } else {
+                        const parts = []
+                        if (contributor.botContributions > 0) {
+                            parts.push(
+                                `${contributor.botContributions} bot contribution${contributor.botContributions !== 1 ? "s" : ""}`,
+                            )
+                        }
+                        if (contributor.websiteContributions > 0) {
+                            parts.push(
+                                `${contributor.websiteContributions} website contribution${contributor.websiteContributions !== 1 ? "s" : ""}`,
+                            )
+                        }
+                        bio = parts.join(" · ")
+                    }
 
                     return {
-                        name: contributor.name, // Use actual display name from GitHub API
+                        name: contributor.name,
                         username: contributor.login,
                         role,
                         avatar: contributor.avatar,
                         contributions: contributor.contributions,
+                        botContributions: contributor.botContributions,
+                        websiteContributions: contributor.websiteContributions,
+                        contributorType: contributor.contributorType,
                         githubUrl: contributor.profile,
                         bio,
+                        description: contributor.description, // Added description from API
                     }
                 })
 
@@ -181,13 +208,17 @@ export default function ContributorsPage() {
      */
     const fallbackContributors: Contributor[] = [
         {
-            name: "Zenitsu", // Updated fallback to use actual display name
+            name: "Zenitsu",
             username: "nayandas69",
             role: "creator",
             avatar: "/developer-working.png",
             contributions: 500,
+            botContributions: 450,
+            websiteContributions: 50,
+            contributorType: "", // Removed label for author
             githubUrl: "https://github.com/nayandas69",
-            bio: CREATOR_BIO,
+            bio: "",
+            description: "Creator and lead developer of Discord Role Guardian", // Added description
         },
     ]
 
@@ -332,12 +363,18 @@ export default function ContributorsPage() {
                                             </div>
                                             <CardTitle className="text-foreground">{contributor.name}</CardTitle>
                                             <CardDescription className="text-muted-foreground">@{contributor.username}</CardDescription>
-                                            <div className="flex justify-center mt-2">
+                                            <div className="flex flex-col items-center gap-2 mt-2">
                                                 <Badge className={`${config.bgColor} ${config.color} border`}>{config.label}</Badge>
+                                                {contributor.contributorType && (
+                                                    <Badge variant="outline" className="text-xs">
+                                                        {contributor.contributorType}
+                                                    </Badge>
+                                                )}
                                             </div>
                                         </CardHeader>
                                         <CardContent className="text-center">
-                                            <p className="mb-4 text-sm text-muted-foreground">{contributor.bio}</p>
+                                            <p className="mb-2 text-sm text-foreground/80 font-medium">{contributor.description}</p>
+                                            {contributor.bio && <p className="mb-4 text-xs text-muted-foreground">{contributor.bio}</p>}
                                             <Link
                                                 href={contributor.githubUrl}
                                                 target="_blank"


### PR DESCRIPTION
## Overview
Enhanced the contributors page to track and display contributions from both the bot repository (`discord-role-guardian`) and the website repository (`drgw`).

## Changes Made

### API Route (`app/api/github/contributors/route.ts`)
- Added parallel fetching from both repositories using GitHub API
- Implemented contributor merging logic to combine contributions from both repos
- Added contributor type categorization:
  - **Bot Contributor**: Only contributed to discord-role-guardian
  - **Website Contributor**: Only contributed to drgw
  - Repo author is excluded from type badges
- Added single-line descriptions for all contributors

### Contributors Page (`app/contributors/page.tsx`)
- Updated contributor card to display contributor type badges
- Added description display for all contributors
- Removed duplicate badge display for repo author (nayandas69)
- Fixed description duplication issue

## 🔍 Testing
- [x] Verified both repositories are fetched correctly
- [x] Confirmed contributor types are accurately categorized
- [x] Tested author card displays without type badge
- [x] Validated descriptions appear without duplication


## Type of Change
- [x] New feature
- [x] Enhancement

## ✅ Checklist
- [x] Code follows project conventions
- [x] TypeScript types are properly defined
- [x] API responses are cached appropriately
- [x] UI is responsive and accessible